### PR TITLE
Fix dash to be release version 1.0.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
             <plugin>
                 <groupId>org.eclipse.dash</groupId>
                 <artifactId>license-tool-plugin</artifactId>
-                <version>1.0.3-SNAPSHOT</version>
+                <version>1.0.2</version>
                 <executions>
                     <execution>
                         <id>license-check</id>
@@ -331,7 +331,7 @@
     <pluginRepositories>
         <pluginRepository>
             <id>dash-licenses-snapshots</id>
-            <url>https://repo.eclipse.org/content/repositories/dash-licenses-snapshots/</url>
+            <url>https://repo.eclipse.org/content/repositories/dash-licenses-releases/</url>
             <snapshots>
                 <enabled>true</enabled>
             </snapshots>


### PR DESCRIPTION
When we release to maven, it complains that it doesn't like that we are pulling in a snapshot of the dash library so changing the code to pull in 1.0.2 release version instead