### PR TITLE
Remove 'Priority' enum from UCloudAttributes class

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/cloudevent/datamodel/UCloudEventAttributes.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/datamodel/UCloudEventAttributes.java
@@ -24,6 +24,8 @@
 
 package org.eclipse.uprotocol.cloudevent.datamodel;
 
+import org.eclipse.uprotocol.v1.UPriority;
+
 import java.util.Objects;
 import java.util.Optional;
 
@@ -35,7 +37,7 @@ public class UCloudEventAttributes {
     private static final UCloudEventAttributes EMPTY = new UCloudEventAttributes(null, null, null, null);
 
     private final String hash;
-    private final Priority priority;
+    private final UPriority priority;
     private final Integer ttl;
     private final String token;
 
@@ -48,7 +50,7 @@ public class UCloudEventAttributes {
      *                 Events without this attribute (or value is 0) MUST NOT timeout.
      * @param token    Oauth2 access token to perform the access request defined in the request message.
      */
-    private UCloudEventAttributes(String hash, Priority priority, Integer ttl, String token) {
+    private UCloudEventAttributes(String hash, UPriority priority, Integer ttl, String token) {
         this.hash = hash;
         this.priority = priority;
         this.ttl = ttl;
@@ -91,7 +93,7 @@ public class UCloudEventAttributes {
      * uProtocol Prioritization classifications.
      * @return Returns an Optional priority attribute.
      */
-    public Optional<Priority> priority() {
+    public Optional<UPriority> priority() {
         return priority == null ? Optional.empty() : Optional.of(priority);
     }
 
@@ -116,7 +118,7 @@ public class UCloudEventAttributes {
      */
     public static class UCloudEventAttributesBuilder {
         private String hash;
-        private Priority priority;
+        private UPriority priority;
         private Integer ttl;
         private String token;
 
@@ -137,7 +139,7 @@ public class UCloudEventAttributes {
          * @param priority uProtocol Prioritization classifications.
          * @return Returns the UCloudEventAttributesBuilder with the configured priority.
          */
-        public UCloudEventAttributesBuilder withPriority(Priority priority) {
+        public UCloudEventAttributesBuilder withPriority(UPriority priority) {
             this.priority = priority;
             return this;
         }
@@ -171,35 +173,6 @@ public class UCloudEventAttributes {
         public UCloudEventAttributes build() {
             // validation if needed
             return new UCloudEventAttributes(this);
-        }
-    }
-
-    /**
-     * Priority according to SDV 202 Quality of Service (QoS) and Prioritization.
-     */
-    public enum Priority {
-        // Low Priority. No bandwidth assurance such as File Transfer.
-        LOW ("CS0"),
-        // Standard, undifferentiated application such as General (unclassified).
-        STANDARD ("CS1"),
-        // Operations, Administration, and Management such as Streamer messages (sub, connect, etc…)
-        OPERATIONS ("CS2"),
-        // Multimedia streaming such as Video Streaming
-        MULTIMEDIA_STREAMING ("CS3"),
-        // Real-time interactive such as High priority (rpc events)
-        REALTIME_INTERACTIVE ("CS4"),
-        // Signaling such as Important
-        SIGNALING("CS5"),
-        // Network control such as Safety Critical
-        NETWORK_CONTROL ("CS6");
-
-        private final String qosString;
-        public String qosString() {
-            return qosString;
-        }
-
-        Priority(String qosString) {
-            this.qosString = qosString;
         }
     }
 

--- a/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
@@ -185,7 +185,8 @@ public interface CloudEventFactory {
                 .withData(protoPayloadBytes);
 
         attributes.ttl().ifPresent(ttl -> cloudEventBuilder.withExtension("ttl", ttl));
-        attributes.priority().ifPresent(priority -> cloudEventBuilder.withExtension("priority", priority.qosString()));
+        attributes.priority().ifPresent(priority -> cloudEventBuilder.withExtension("priority",
+                String.valueOf(priority)));
         attributes.hash().ifPresent(hash -> cloudEventBuilder.withExtension("hash", hash));
         attributes.token().ifPresent(token -> cloudEventBuilder.withExtension("token", token));
 

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/datamodel/UCloudEventAttributesTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/datamodel/UCloudEventAttributesTest.java
@@ -25,6 +25,7 @@
 package org.eclipse.uprotocol.cloudevent.datamodel;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.eclipse.uprotocol.v1.UPriority;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -43,11 +44,11 @@ class UCloudEventAttributesTest {
     public void testToString() {
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.STANDARD)
+                .withPriority(UPriority.UPRIORITY_CS1)
                 .withTtl(3)
                 .withToken("someOAuthToken")
                 .build();
-        String expected = "UCloudEventAttributes{hash='somehash', priority=STANDARD, ttl=3, token='someOAuthToken'}";
+        String expected = "UCloudEventAttributes{hash='somehash', priority=UPRIORITY_CS1, ttl=3, token='someOAuthToken'}";
         assertEquals(expected, uCloudEventAttributes.toString());
 
     }
@@ -57,14 +58,14 @@ class UCloudEventAttributesTest {
     public void test_create_valid() {
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.NETWORK_CONTROL)
+                .withPriority(UPriority.UPRIORITY_CS6)
                 .withTtl(3)
                 .withToken("someOAuthToken")
                 .build();
         assertTrue(uCloudEventAttributes.hash().isPresent());
         assertEquals("somehash", uCloudEventAttributes.hash().get());
         assertTrue(uCloudEventAttributes.priority().isPresent());
-        assertEquals(UCloudEventAttributes.Priority.NETWORK_CONTROL, uCloudEventAttributes.priority().get());
+        assertEquals(UPriority.UPRIORITY_CS6, uCloudEventAttributes.priority().get());
         assertTrue(uCloudEventAttributes.ttl().isPresent());
         assertEquals(3, uCloudEventAttributes.ttl().get());
         assertTrue(uCloudEventAttributes.token().isPresent());
@@ -118,7 +119,7 @@ class UCloudEventAttributesTest {
         assertFalse(uCloudEventAttributes3.isEmpty());
 
         final UCloudEventAttributes uCloudEventAttributes4 = new UCloudEventAttributes.UCloudEventAttributesBuilder()
-                .withPriority(UCloudEventAttributes.Priority.LOW)
+                .withPriority(UPriority.UPRIORITY_CS0)
                 .build();
         assertFalse(uCloudEventAttributes4.isEmpty());
 

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactoryTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactoryTest.java
@@ -32,6 +32,7 @@ import org.eclipse.uprotocol.cloudevent.datamodel.UCloudEventAttributes;
 import org.eclipse.uprotocol.cloudevent.datamodel.UCloudEventType;
 import org.eclipse.uprotocol.uri.serializer.LongUriSerializer;
 import org.eclipse.uprotocol.v1.UEntity;
+import org.eclipse.uprotocol.v1.UPriority;
 import org.eclipse.uprotocol.v1.UResource;
 import org.eclipse.uprotocol.v1.UUri;
 import org.junit.jupiter.api.DisplayName;
@@ -58,7 +59,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.STANDARD)
+                .withPriority(UPriority.UPRIORITY_CS1)
                 .withTtl(3)
                 .withToken("someOAuthToken")
                 .build();
@@ -77,7 +78,7 @@ class CloudEventFactoryTest {
         assertEquals(UCloudEventType.PUBLISH.type(), cloudEvent.getType());
         assertFalse(cloudEvent.getExtensionNames().contains("sink"));
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.STANDARD.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS1.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
         assertEquals("someOAuthToken", cloudEvent.getExtension("token"));
 
@@ -96,7 +97,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.STANDARD)
+                .withPriority(UPriority.UPRIORITY_CS1)
                 .withTtl(3)
                 .withToken("someOAuthToken")
                 .build();
@@ -121,7 +122,7 @@ class CloudEventFactoryTest {
                 Objects.requireNonNull(cloudEvent.getDataSchema()).toString());
         assertFalse(cloudEvent.getExtensionNames().contains("sink"));
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.STANDARD.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS1.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
         assertEquals("someOAuthToken", cloudEvent.getExtension("token"));
 
@@ -174,7 +175,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.STANDARD)
+                .withPriority(UPriority.UPRIORITY_CS1)
                 .withTtl(3)
                 .build();
 
@@ -186,7 +187,7 @@ class CloudEventFactoryTest {
         assertEquals(UCloudEventType.PUBLISH.type(), cloudEvent.getType());
         assertFalse(cloudEvent.getExtensionNames().contains("sink"));
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.STANDARD.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS1.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
 
         assertArrayEquals(protoPayload.toByteArray(), Objects.requireNonNull(cloudEvent.getData()).toBytes());
@@ -208,7 +209,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.OPERATIONS)
+                .withPriority(UPriority.UPRIORITY_CS2)
                 .withTtl(3)
                 .build();
 
@@ -224,7 +225,7 @@ class CloudEventFactoryTest {
 
         assertEquals(UCloudEventType.PUBLISH.type(), cloudEvent.getType());
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.OPERATIONS.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS2.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
 
         assertArrayEquals(protoPayload.toByteArray(), Objects.requireNonNull(cloudEvent.getData()).toBytes());
@@ -247,7 +248,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.OPERATIONS)
+                .withPriority(UPriority.UPRIORITY_CS2)
                 .withTtl(3)
                 .withToken("someOAuthToken")
                 .build();
@@ -264,7 +265,7 @@ class CloudEventFactoryTest {
 
         assertEquals("req.v1", cloudEvent.getType());
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.OPERATIONS.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS2.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
         assertEquals("someOAuthToken", cloudEvent.getExtension("token"));
 
@@ -289,7 +290,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.OPERATIONS)
+                .withPriority(UPriority.UPRIORITY_CS2)
                 .withTtl(3)
                 .build();
 
@@ -305,7 +306,7 @@ class CloudEventFactoryTest {
 
         assertEquals("res.v1", cloudEvent.getType());
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.OPERATIONS.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS2.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
 
         assertEquals("requestIdFromRequestCloudEvent", cloudEvent.getExtension("reqid"));
@@ -328,7 +329,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.OPERATIONS)
+                .withPriority(UPriority.UPRIORITY_CS2)
                 .withTtl(3)
                 .build();
 
@@ -346,7 +347,7 @@ class CloudEventFactoryTest {
 
         assertEquals("res.v1", cloudEvent.getType());
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.OPERATIONS.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS2.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
         assertEquals(Code.INVALID_ARGUMENT_VALUE, cloudEvent.getExtension("commstatus"));
 
@@ -368,7 +369,7 @@ class CloudEventFactoryTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.OPERATIONS)
+                .withPriority(UPriority.UPRIORITY_CS2)
                 .withTtl(3)
                 .build();
 
@@ -386,7 +387,7 @@ class CloudEventFactoryTest {
 
         assertEquals("res.v1", cloudEvent.getType());
         assertEquals("somehash", cloudEvent.getExtension("hash"));
-        assertEquals(UCloudEventAttributes.Priority.OPERATIONS.qosString(), cloudEvent.getExtension("priority"));
+        assertEquals(UPriority.UPRIORITY_CS2.name(), cloudEvent.getExtension("priority"));
         assertEquals(3, cloudEvent.getExtension("ttl"));
         assertEquals(Code.INVALID_ARGUMENT_VALUE, cloudEvent.getExtension("commstatus"));
 

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/factory/UCloudEventTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/factory/UCloudEventTest.java
@@ -36,10 +36,7 @@ import org.eclipse.uprotocol.uri.serializer.LongUriSerializer;
 import org.eclipse.uprotocol.uuid.factory.UuidFactory;
 import org.eclipse.uprotocol.uuid.factory.UuidUtils;
 import org.eclipse.uprotocol.uuid.serializer.LongUuidSerializer;
-import org.eclipse.uprotocol.v1.UEntity;
-import org.eclipse.uprotocol.v1.UResource;
-import org.eclipse.uprotocol.v1.UUID;
-import org.eclipse.uprotocol.v1.UUri;
+import org.eclipse.uprotocol.v1.*;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -154,7 +151,7 @@ class UCloudEventTest {
 
         final Optional<String> priority = UCloudEvent.getPriority(cloudEvent);
         assertTrue(priority.isPresent());
-        Assertions.assertEquals(UCloudEventAttributes.Priority.STANDARD.qosString(), priority.get());
+        Assertions.assertEquals(UPriority.UPRIORITY_CS1.name(), priority.get());
     }
 
     @Test
@@ -667,7 +664,7 @@ class UCloudEventTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes =
                 new UCloudEventAttributes.UCloudEventAttributesBuilder().withHash(
-                        "somehash").withPriority(UCloudEventAttributes.Priority.STANDARD).withTtl(3).withToken(
+                        "somehash").withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken(
                                 "someOAuthToken")
                 .build();
 

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToJsonSerializerTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToJsonSerializerTest.java
@@ -34,6 +34,7 @@ import org.eclipse.uprotocol.cloudevent.datamodel.UCloudEventType;
 import org.eclipse.uprotocol.cloudevent.factory.CloudEventFactory;
 import org.eclipse.uprotocol.cloudevent.factory.UCloudEvent;
 
+import org.eclipse.uprotocol.v1.UPriority;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -170,7 +171,7 @@ class CloudEventToJsonSerializerTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.STANDARD)
+                .withPriority(UPriority.UPRIORITY_CS1)
                 .withTtl(3)
                 .withToken("someOAuthToken")
                 .build();

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToProtobufSerializerTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/serialize/CloudEventToProtobufSerializerTest.java
@@ -35,6 +35,7 @@ import org.eclipse.uprotocol.cloudevent.factory.CloudEventFactory;
 import org.eclipse.uprotocol.cloudevent.factory.UCloudEvent;
 import org.eclipse.uprotocol.uri.serializer.LongUriSerializer;
 import org.eclipse.uprotocol.v1.UEntity;
+import org.eclipse.uprotocol.v1.UPriority;
 import org.eclipse.uprotocol.v1.UResource;
 import org.eclipse.uprotocol.v1.UUri;
 import org.junit.jupiter.api.DisplayName;
@@ -65,7 +66,7 @@ class CloudEventToProtobufSerializerTest {
         // configure cloud event
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.LOW)
+                .withPriority(UPriority.UPRIORITY_CS0)
                 .withTtl(3)
                 .build();
 
@@ -152,7 +153,7 @@ class CloudEventToProtobufSerializerTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
                 .withHash("somehash")
-                .withPriority(UCloudEventAttributes.Priority.STANDARD)
+                .withPriority(UPriority.UPRIORITY_CS1)
                 .withTtl(3)
                 .withToken("someOAuthToken")
                 .build();

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/validate/CloudEventValidatorTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/validate/CloudEventValidatorTest.java
@@ -37,10 +37,7 @@ import org.eclipse.uprotocol.uri.serializer.LongUriSerializer;
 import org.eclipse.uprotocol.uuid.factory.UuidFactory;
 import org.eclipse.uprotocol.uuid.factory.UuidUtils;
 import org.eclipse.uprotocol.uuid.serializer.LongUuidSerializer;
-import org.eclipse.uprotocol.v1.UEntity;
-import org.eclipse.uprotocol.v1.UResource;
-import org.eclipse.uprotocol.v1.UUID;
-import org.eclipse.uprotocol.v1.UUri;
+import org.eclipse.uprotocol.v1.*;
 import org.eclipse.uprotocol.validation.ValidationResult;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -556,7 +553,7 @@ class CloudEventValidatorTest {
         // additional attributes
         final UCloudEventAttributes uCloudEventAttributes =
                 new UCloudEventAttributes.UCloudEventAttributesBuilder().withHash(
-                        "somehash").withPriority(UCloudEventAttributes.Priority.STANDARD).withTtl(3).withToken(
+                        "somehash").withPriority(UPriority.UPRIORITY_CS1).withTtl(3).withToken(
                                 "someOAuthToken")
                 .build();
 
@@ -588,7 +585,7 @@ class CloudEventValidatorTest {
         final Any protoPayload = buildProtoPayloadForTest();
 
         final UCloudEventAttributes attributes = new UCloudEventAttributes.UCloudEventAttributesBuilder().withPriority(
-                        UCloudEventAttributes.Priority.LOW).withTtl(1000) // live for 1 second
+                        UPriority.UPRIORITY_CS0).withTtl(1000) // live for 1 second
                 .build();
 
         // build the cloud event
@@ -614,7 +611,7 @@ class CloudEventValidatorTest {
         final Any protoPayload = buildProtoPayloadForTest();
 
         final UCloudEventAttributes attributes = new UCloudEventAttributes.UCloudEventAttributesBuilder().withPriority(
-                        UCloudEventAttributes.Priority.LOW).withTtl(1000) // live for 1 second
+                        UPriority.UPRIORITY_CS0).withTtl(1000) // live for 1 second
                 .build();
 
         // build the cloud event


### PR DESCRIPTION
In this commit, we've taken out the Priority enum from the UCloudAttributes class and replaced it with the UPriority enum as defined in the uattributes.proto file. This change guarantees a uniform use of priority across the entire codebase.