### PR TITLE
Update maven release rule

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,8 @@ jobs:
 
     - name: Stage to Nexus and Release to Maven central
       run: |
-        mvn -B release:clean release:prepare -P release release:perform
+        mvn -B release:clean release:prepare -P release release:perform -DpushChanges=false
+        git push —tags
       env:
         OSSRH_USER: ${{ secrets.ORG_OSSRH_USERNAME }}
         OSSRH_PASSWORD: ${{ secrets.ORG_OSSRH_PASSWORD }}


### PR DESCRIPTION
Update Maven release rule

This commit modifies the Maven release rule to align with the resolution discussed in GitLab issue #3944 (https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3944).