### PR TITLE
Remove uprotocol-core-api dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
         <slf4j.version>2.6.18</slf4j.version>
         <cloudevents.version>2.4.2</cloudevents.version>
         <protobuf.version>3.21.10</protobuf.version>
+        <git.tag.name>uprotocol-core-api-1.5.3</git.tag.name>
     </properties>
 
     <licenses>
@@ -88,10 +89,30 @@
                             <arguments>
                                 <argument>clone</argument>
                                 <argument>--branch</argument>
-                                <argument>uprotocol-core-api-1.5.3</argument>
+                                <argument>${git.tag.name}</argument>
                                 <argument>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</argument>
                                 <argument>${project.build.directory}/uprotocol-core-api</argument>
-
+                            </arguments>
+                            <!-- Allow non-zero exit code (error) -->
+                            <successCodes>
+                                <successCode>0</successCode>
+                                <successCode>128</successCode> <!-- Git error code for existing repository -->
+                            </successCodes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pull-repository</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+                            <workingDirectory>${project.build.directory}/uprotocol-core-api</workingDirectory>
+                            <arguments>
+                                <argument>pull</argument>
+                                <argument>origin</argument>
+                                <argument>${git.tag.name}</argument>
                             </arguments>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,29 @@
         </extensions>
 
         <plugins>
-                 
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <id>clone-repository</id>
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>exec</goal>
+                        </goals>
+                        <configuration>
+                            <executable>git</executable>
+                            <arguments>
+                                <argument>clone</argument>
+                                <argument>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</argument>
+                                <argument>${project.build.directory}/uprotocol-core-api</argument>
+
+                            </arguments>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
@@ -92,6 +114,25 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
                 <version>3.1.0</version>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
+                <artifactId>protobuf-maven-plugin</artifactId>
+                <version>0.6.1</version> <!-- Use the latest version -->
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>compile</goal>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <protocArtifact>com.google.protobuf:protoc:3.17.3:exe:${os.detected.classifier}</protocArtifact>
+                    <protoSourceRoot>${project.build.directory}/uprotocol-core-api/src/main/proto</protoSourceRoot>
+                    <outputDirectory>${project.build.directory}/generated-sources/protobuf/java</outputDirectory>
+
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
@@ -319,14 +360,7 @@
             <artifactId>commons-validator</artifactId>
             <version>1.7</version>
         </dependency>
-        
-        <!-- uProtocol core API library -->
-        <dependency>
-            <groupId>org.eclipse.uprotocol</groupId>
-            <artifactId>uprotocol-core-api</artifactId>
-            <version>1.5.2</version>
-        </dependency>
-        
+
         <!-- JSON library for JUnit test cases -->
         <dependency>
             <groupId>org.json</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,8 +84,11 @@
                         </goals>
                         <configuration>
                             <executable>git</executable>
+
                             <arguments>
                                 <argument>clone</argument>
+                                <argument>--branch</argument>
+                                <argument>uprotocol-core-api-1.5.3</argument>
                                 <argument>https://github.com/eclipse-uprotocol/uprotocol-core-api.git</argument>
                                 <argument>${project.build.directory}/uprotocol-core-api</argument>
 


### PR DESCRIPTION
This commit addresses issue #54 by eliminating the uprotocol-core-api dependency. Protos are now pulled directly from GitHub and compiled within the project