### PR TITLE
Fix: UAttributesValidator now correctly handles the sink attribute.

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/transport/validate/UAttributesValidator.java
+++ b/src/main/java/org/eclipse/uprotocol/transport/validate/UAttributesValidator.java
@@ -26,11 +26,7 @@ package org.eclipse.uprotocol.transport.validate;
 
 import org.eclipse.uprotocol.uri.validator.UriValidator;
 import org.eclipse.uprotocol.uuid.factory.UuidUtils;
-import org.eclipse.uprotocol.v1.UAttributes;
-import org.eclipse.uprotocol.v1.UMessageType;
-import org.eclipse.uprotocol.v1.UUID;
-import org.eclipse.uprotocol.v1.UStatus;
-import org.eclipse.uprotocol.v1.UCode;
+import org.eclipse.uprotocol.v1.*;
 import org.eclipse.uprotocol.validation.ValidationResult;
 
 import java.util.Objects;
@@ -274,7 +270,7 @@ public abstract class UAttributesValidator {
             if (!attributes.hasSink()) {
                 return ValidationResult.failure("Missing Sink");
             }
-            return UriValidator.validateRpcResponse(attributes.getSink());
+            return UriValidator.validateRpcMethod(attributes.getSink());
 
         }
 
@@ -332,13 +328,11 @@ public abstract class UAttributesValidator {
         @Override
         public ValidationResult validateSink(UAttributes attributes) {
             Objects.requireNonNull(attributes, "UAttributes cannot be null.");
-
-            ValidationResult result = UriValidator.validateRpcMethod(attributes.getSink());
-            if (result.isSuccess()) {
-                return result;
-            } else {
+            if (!attributes.hasSink()|| attributes.getSink() == UUri.getDefaultInstance()) {
                 return ValidationResult.failure("Missing Sink");
             }
+            ValidationResult result = UriValidator.validateRpcResponse(attributes.getSink());
+            return result;
 
         }
 

--- a/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.java
+++ b/src/test/java/org/eclipse/uprotocol/transport/validator/UAttributesValidatorTest.java
@@ -650,10 +650,59 @@ class UAttributesValidatorTest {
         assertEquals(ValidationResult.success(), status);
     }
 
+    @Test
+    @DisplayName("test_valid_request_methoduri_in_sink")
+    public void test_valid_request_methoduri_in_sink(){
+        final UUri sink= LongUriSerializer.instance().deserialize("/test.service/1/rpc.method");
+        final UAttributes attributes =
+                UAttributesBuilder.request(UPriority.UPRIORITY_CS0,sink,3000).build();
+        final UAttributesValidator validator = UAttributesValidator.getValidator(attributes);
+        assertEquals("UAttributesValidator.Request", validator.toString());
+        final ValidationResult status = validator.validate(attributes);
+        assertEquals(ValidationResult.success(), status);
+    }
+
+    @Test
+    @DisplayName("test_invalid_request_methoduri_in_sink")
+    public void test_invalid_request_methoduri_in_sink(){
+        final UUri sink= LongUriSerializer.instance().deserialize("/test.client/1/test.response");
+        final UAttributes attributes =
+                UAttributesBuilder.request(UPriority.UPRIORITY_CS0,sink,3000).build();
+        final UAttributesValidator validator = UAttributesValidator.getValidator(attributes);
+        assertEquals("UAttributesValidator.Request", validator.toString());
+        final ValidationResult status = validator.validate(attributes);
+        assertEquals("Invalid RPC method uri. Uri should be the method to be called, or method from response.", status.getMessage());
+    }
+
+    @Test
+    @DisplayName("test_valid_response_uri_in_sink")
+    public void test_valid_response_uri_in_sink(){
+        final UUri sink= LongUriSerializer.instance().deserialize("/test.client/1/rpc.response");
+        final UAttributes attributes =
+                UAttributesBuilder.response(UPriority.UPRIORITY_CS0,sink,UuidFactory.Factories.UPROTOCOL.factory().create()).build();
+        final UAttributesValidator validator = UAttributesValidator.getValidator(attributes);
+        assertEquals("UAttributesValidator.Response", validator.toString());
+        final ValidationResult status = validator.validate(attributes);
+        assertEquals(ValidationResult.success(), status);
+    }
+
+    @Test
+    @DisplayName("test_invalid_response_uri_in_sink")
+    public void test_invalid_response_uri_in_sink(){
+        final UUri sink= LongUriSerializer.instance().deserialize("/test.client/1/rpc.method");
+        final UAttributes attributes =
+                UAttributesBuilder.response(UPriority.UPRIORITY_CS0,sink,UuidFactory.Factories.UPROTOCOL.factory().create()).build();
+        final UAttributesValidator validator = UAttributesValidator.getValidator(attributes);
+        assertEquals("UAttributesValidator.Response", validator.toString());
+        final ValidationResult status = validator.validate(attributes);
+        assertEquals("Invalid RPC response type.", status.getMessage());
+    }
+
     private UUri buildSink() {
         return UUri.newBuilder().setAuthority(UAuthority.newBuilder().setName("vcu.someVin.veh.ultifi.gm.com"))
                 .setEntity(UEntity.newBuilder().setName("petapp.ultifi.gm.com").setVersionMajor(1))
                 .setResource(UResourceBuilder.forRpcResponse()).build();
     }
+
 
 }


### PR DESCRIPTION
This commit addresses Issue #64 , where the UAttributesValidator was found to incorrectly handle the sink attribute for RPC request and response messages.