### PR TITLE
 Add backward compatibility for CloudEvents with old priority("CS1","…

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/cloudevent/README.adoc
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/README.adoc
@@ -90,7 +90,7 @@ assertEquals(UCloudEvent.getTtl(cloudEvent).get(), result.getAttributes().getTtl
 assertEquals(UCloudEvent.getPayload(cloudEvent).toByteString(),result.getPayload().getValue());
 assertEquals(UCloudEvent.getSource(cloudEvent),LongUriSerializer.instance().serialize(result.getSource()));
 assertTrue(UCloudEvent.getPriority(cloudEvent).isPresent());
-assertEquals(UCloudEvent.getPriority(cloudEvent).get(), String.valueOf(result.getAttributes().getPriority()));
+assertEquals(UCloudEvent.getPriority(cloudEvent).get(), result.getAttributes().getPriority().name());
 
 final CloudEvent cloudEvent1 = UCloudEvent.fromMessage(result);
 assertEquals(cloudEvent,cloudEvent1);

--- a/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/factory/CloudEventFactory.java
@@ -186,7 +186,7 @@ public interface CloudEventFactory {
 
         attributes.ttl().ifPresent(ttl -> cloudEventBuilder.withExtension("ttl", ttl));
         attributes.priority().ifPresent(priority -> cloudEventBuilder.withExtension("priority",
-                String.valueOf(priority)));
+                priority.name()));
         attributes.hash().ifPresent(hash -> cloudEventBuilder.withExtension("hash", hash));
         attributes.token().ifPresent(token -> cloudEventBuilder.withExtension("token", token));
 

--- a/src/main/java/org/eclipse/uprotocol/cloudevent/factory/UCloudEvent.java
+++ b/src/main/java/org/eclipse/uprotocol/cloudevent/factory/UCloudEvent.java
@@ -371,7 +371,7 @@ public interface UCloudEvent {
         if (hasCommunicationStatusProblem(event)) {
             builder.setCommstatus(getCommunicationStatus(event));
         }
-        getPriority(event).map(UPriority::valueOf).ifPresent(builder::setPriority);
+        getPriority(event).map(p -> p.startsWith("UPRIORITY_") ? p : "UPRIORITY_" + p).map(UPriority::valueOf).ifPresent(builder::setPriority);
 
         getSink(event).map(LongUriSerializer.instance()::deserialize).ifPresent(builder::setSink);
 
@@ -422,7 +422,7 @@ public interface UCloudEvent {
             cloudEventBuilder.withExtension("token",attributes.getToken());
 
         if(attributes.getPriorityValue()>0)
-            cloudEventBuilder.withExtension("priority",String.valueOf(attributes.getPriority()));
+            cloudEventBuilder.withExtension("priority",attributes.getPriority().name());
 
         if(attributes.hasSink())
             cloudEventBuilder.withExtension("sink",

--- a/src/test/java/org/eclipse/uprotocol/cloudevent/factory/UCloudEventTest.java
+++ b/src/test/java/org/eclipse/uprotocol/cloudevent/factory/UCloudEventTest.java
@@ -772,7 +772,7 @@ class UCloudEventTest {
         assertEquals(UCloudEvent.getPayload(cloudEvent).toByteString(),result.getPayload().getValue());
         assertEquals(UCloudEvent.getSource(cloudEvent),LongUriSerializer.instance().serialize(result.getSource()));
         assertTrue(UCloudEvent.getPriority(cloudEvent).isPresent());
-        assertEquals(UCloudEvent.getPriority(cloudEvent).get(), String.valueOf(result.getAttributes().getPriority()));
+        assertEquals(UCloudEvent.getPriority(cloudEvent).get(),result.getAttributes().getPriority().name());
 
         final CloudEvent cloudEvent1 = UCloudEvent.fromMessage(result);
         assertEquals(cloudEvent,cloudEvent1);
@@ -829,7 +829,7 @@ class UCloudEventTest {
         assertEquals(UCloudEvent.getPayload(cloudEvent).toByteString(),result.getPayload().getValue());
         assertEquals(UCloudEvent.getSource(cloudEvent),LongUriSerializer.instance().serialize(result.getSource()));
         assertTrue(UCloudEvent.getPriority(cloudEvent).isPresent());
-        assertEquals(UCloudEvent.getPriority(cloudEvent).get(), String.valueOf(result.getAttributes().getPriority()));
+        assertEquals(UCloudEvent.getPriority(cloudEvent).get(), result.getAttributes().getPriority().name());
 
         final CloudEvent cloudEvent1 = UCloudEvent.fromMessage(result);
         assertEquals(cloudEvent,cloudEvent1);
@@ -939,6 +939,30 @@ class UCloudEventTest {
 
     }
 
+    @Test
+    public void test_to_from_message_from_UCP_cloudevent(){
+        // additional attributes
+        final UCloudEventAttributes uCloudEventAttributes = new UCloudEventAttributes.UCloudEventAttributesBuilder()
+                .withTtl(3)
+                .build();
+
+        Any protoPayload= buildProtoPayloadForTest();
+        final CloudEventBuilder cloudEventBuilder =
+                CloudEventFactory.buildBaseCloudEvent(LongUuidSerializer.instance().serialize(UuidFactory.Factories.UPROTOCOL.factory().create()), buildSourceForTest(),
+                        protoPayload.toByteArray(), protoPayload.getTypeUrl(), uCloudEventAttributes);
+        cloudEventBuilder.withType(UCloudEvent.getEventType(UMessageType.UMESSAGE_TYPE_PUBLISH));
+        cloudEventBuilder.withExtension("priority","CS4");
+
+        CloudEvent cloudEvent = cloudEventBuilder.build();
+
+        UMessage result = UCloudEvent.toMessage(cloudEvent);
+        assertNotNull(result);
+        assertEquals(UPriority.UPRIORITY_CS4.name(),result.getAttributes().getPriority().name());
+        CloudEvent cloudEvent1 = UCloudEvent.fromMessage(result);
+        assertTrue(UCloudEvent.getPriority(cloudEvent1).isPresent());
+        assertEquals(UPriority.UPRIORITY_CS4.name(),UCloudEvent.getPriority(cloudEvent1).get());
+
+    }
     private String buildSourceForTest(){
         UUri Uri = UUri.newBuilder().setEntity(UEntity.newBuilder().setName("body.access"))
                 .setResource(UResource.newBuilder().setName("door").setInstance("front_left").setMessage("Door"))


### PR DESCRIPTION
This commit addresses Issue https://github.com/eclipse-uprotocol/uprotocol-java/issues/67