### PR TITLE
Use upper case hex-encoding in UriSerializer

### DIFF
--- a/src/main/java/org/eclipse/uprotocol/uri/serializer/UriSerializer.java
+++ b/src/main/java/org/eclipse/uprotocol/uri/serializer/UriSerializer.java
@@ -44,12 +44,12 @@ public interface UriSerializer {
         }
 
         sb.append("/");
-        sb.append(Integer.toHexString(uri.getUeId()));
-        sb.append("/");
-        sb.append(Integer.toHexString(uri.getUeVersionMajor()));
-        sb.append("/");
-        sb.append(Integer.toHexString(uri.getResourceId()));
-        return sb.toString().replaceAll("/+$", "");
+        final var pathSegments = String.format("%X/%X/%X",
+                uri.getUeId(),
+                uri.getUeVersionMajor(),
+                uri.getResourceId());
+        sb.append(pathSegments);
+        return sb.toString();
     }
 
     /**


### PR DESCRIPTION
The UriSerializer has been adapted to produce upper case hex-encoded
strings for numeric UUri components.

Fixes #185